### PR TITLE
SM2密钥交换方法初始化

### DIFF
--- a/sm2/sm2_keyexchange_test.go
+++ b/sm2/sm2_keyexchange_test.go
@@ -41,3 +41,53 @@ func TestKeyExchangeSample(t *testing.T) {
 		t.Errorf("got different key")
 	}
 }
+
+func TestKeyExchangeNoPeerPubInit(t *testing.T) {
+	priv1, _ := GenerateKey(rand.Reader)
+	priv2, _ := GenerateKey(rand.Reader)
+	uidA := []byte("Alice")
+	uidB := []byte("Bob")
+
+	initiator, err := NewKeyExchange(priv1, nil, uidA, uidB, 32, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	responder, err := NewKeyExchange(priv2, nil, uidB, uidA, 32, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rA, err := initiator.InitKeyExchange(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// 设置对端参数
+	err = initiator.SetPeerPub(&priv2.PublicKey, uidB)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = responder.SetPeerPub(&priv1.PublicKey, uidA)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rB, s2, err := responder.RepondKeyExchange(rand.Reader, rA)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s1, err := initiator.ConfirmResponder(rB, s2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = responder.ConfirmInitiator(s1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if hex.EncodeToString(initiator.key) != hex.EncodeToString(responder.key) {
+		t.Errorf("got different key")
+	}
+}


### PR DESCRIPTION
修改了SM2密钥交换方法，在初始化构造 `KeyExchange` 对象时，不强制要求需要对端的公开信息 公钥、UID。
可以在合适的实际通过`KeyExchange.SetPeerPub` 方法设置对端公钥。


该修改主要用于TLCP协议的ECDHE套件的密钥交换实现，TLCP的ECDHE与TLS不一致，采用SM2的密钥交换机制作为密钥交换的实现。

在服务端发送服务端的密钥交换消息时，服务端还没有客户端的公钥，客户端的公钥需要后续的客户端证书消息中才能发送至服务端，因此需要做此调整，如下所示：

![image](https://user-images.githubusercontent.com/17817790/184473952-be42e0df-194f-4675-be83-b1369e25002e.png)
