### PR TITLE
sm9: Prevent PublicKey() returning nil after unmarshaling master priavate key

### DIFF
--- a/sm9/sm9_key.go
+++ b/sm9/sm9_key.go
@@ -114,7 +114,13 @@ func UnmarshalSignMasterPrivateKeyASN1(der []byte) (*SignMasterPrivateKey, error
 	if err != nil {
 		return nil, err
 	}
-	return &SignMasterPrivateKey{privateKey: priv.Bytes(), internal: priv}, nil
+
+	master := &SignMasterPrivateKey{privateKey: priv.Bytes(), internal: priv}
+	master.publicKey = &SignMasterPublicKey{
+		publicKey: priv.PublicKey().Bytes(),
+		internal:  priv.PublicKey(),
+	}
+	return master, nil
 }
 
 // GenerateUserKey generate a signature private key for the given user.
@@ -370,7 +376,13 @@ func UnmarshalEncryptMasterPrivateKeyASN1(der []byte) (*EncryptMasterPrivateKey,
 	if err != nil {
 		return nil, err
 	}
-	return &EncryptMasterPrivateKey{privateKey: privateKey.Bytes(), internal: privateKey}, nil
+
+	master := &EncryptMasterPrivateKey{privateKey: privateKey.Bytes(), internal: privateKey}
+	master.publicKey = &EncryptMasterPublicKey{
+		publicKey: privateKey.PublicKey().Bytes(),
+		internal:  privateKey.PublicKey(),
+	}
+	return master, nil
 }
 
 // Equal compares the receiver EncryptMasterPublicKey with another EncryptMasterPublicKey

--- a/sm9/sm9_key_test.go
+++ b/sm9/sm9_key_test.go
@@ -27,6 +27,11 @@ func TestSignMasterPrivateKeyMarshalASN1(t *testing.T) {
 	if !masterKey.Equal(masterKey2) {
 		t.Errorf("expected %v, got %v", hex.EncodeToString(masterKey.Bytes()), hex.EncodeToString(masterKey2.Bytes()))
 	}
+
+	masterPubKey := masterKey2.PublicKey()
+	if masterPubKey == nil {
+		t.Fatal("cannot export public key")
+	}
 }
 
 func TestSignMasterPublicKeyMarshalASN1(t *testing.T) {
@@ -128,6 +133,11 @@ func TestEncryptMasterPrivateKeyMarshalASN1(t *testing.T) {
 	}
 	if !masterKey.Equal(masterKey2) {
 		t.Errorf("expected %v, got %v", hex.EncodeToString(masterKey.Bytes()), hex.EncodeToString(masterKey2.Bytes()))
+	}
+
+	masterPubKey := masterKey2.PublicKey()
+	if masterPubKey == nil {
+		t.Fatal("cannot export public key")
 	}
 }
 


### PR DESCRIPTION
During unmarshaling of SignMasterPrivateKey and EncryptMasterPrivateKey, now generate the corresponding public key.
This ensures that PublicKey() does not return nil.

Test cases included to validate the changes.