### PR TITLE
增加了DRBG销毁内部状态的方法

### DIFF
--- a/drbg/common.go
+++ b/drbg/common.go
@@ -7,6 +7,8 @@ import (
 	"errors"
 	"hash"
 	"io"
+	"runtime"
+	"sync/atomic"
 	"time"
 
 	"github.com/emmansun/gmsm/sm3"
@@ -226,6 +228,8 @@ type DRBG interface {
 	Generate(b, additional []byte) error
 	// MaxBytesPerRequest return max bytes per request
 	MaxBytesPerRequest() int
+	// Destroy internal state
+	Destroy()
 }
 
 type BaseDrbg struct {
@@ -255,6 +259,26 @@ func (hd *BaseDrbg) setSecurityLevel(securityLevel SecurityLevel) {
 	default:
 		hd.reseedIntervalInCounter = reseedCounterIntervalLevel1
 		hd.reseedIntervalInTime = reseedTimeIntervalLevel1
+	}
+}
+
+// Destroy 对 GM/T 0105-2021 B.2、E.2 对内部状态进行清零处理
+// 内部状态组成为 {V,C, reseed_counter, last_reseed_time,reseed_interval_in_counter, reseed_interval_in_time}
+// 内部状态组成为 {V,Key, reseed_counter, last_reseed_time,reseed_interval_in_counter, reseed_interval_in_time}
+func (cd *BaseDrbg) Destroy() {
+	setZero(cd.v)
+	cd.seedLength = 0
+	for i := 0; i < 3; i++ {
+		// 使用原子操作防止编译器优化
+		atomic.StoreUint64(&cd.reseedCounter, 0xFFFFFFFFFFFFFFFF)
+		atomic.StoreUint64(&cd.reseedCounter, 0x00)
+		atomic.StoreUint64(&cd.reseedIntervalInCounter, 0xFFFFFFFFFFFFFFFF)
+		atomic.StoreUint64(&cd.reseedIntervalInCounter, 0x00)
+		// 将 reseedIntervalInTime 设置内存屏障，防止编译器优化
+		cd.reseedIntervalInTime = time.Duration(1<<63 - 1)
+		runtime.KeepAlive(&cd.reseedIntervalInTime)
+		cd.reseedIntervalInTime = time.Duration(0)
+		cd.reseedTime = time.Now()
 	}
 }
 
@@ -290,5 +314,28 @@ func addOne(data []byte, len int) {
 		temp += uint16(data[i])
 		data[i] = byte(temp & 0xff)
 		temp >>= 8
+	}
+}
+
+// setZero tries best to clear the sensitive data in memory by overwriting it with 0xFF and 0 for 3 times.
+// - data: the byte slice to be cleared.
+func setZero(data []byte) {
+	if data == nil {
+		return
+	}
+	for j := 0; j < 3; j++ {
+		// 先写入0xFF
+		for i := range data {
+			data[i] = 0xFF
+		}
+		// 内存屏障，确保写入0xFF完成
+		runtime.KeepAlive(data)
+
+		// 再写入0
+		for i := range data {
+			data[i] = 0
+		}
+		// 再次内存屏障，确保写入0完成
+		runtime.KeepAlive(data)
 	}
 }

--- a/drbg/common_test.go
+++ b/drbg/common_test.go
@@ -95,7 +95,6 @@ func TestNistHashDrbgPrng(t *testing.T) {
 	}
 }
 
-
 func TestNistHmacDrbgPrng(t *testing.T) {
 	prng, err := NewNistHmacDrbgPrng(sha256.New, nil, 32, SECURITY_LEVEL_TEST, nil)
 	if err != nil {
@@ -119,5 +118,26 @@ func TestGMSecurityStrengthValidation(t *testing.T) {
 	_, err = NewGmCtrDrbgPrng(nil, 24, SECURITY_LEVEL_TEST, nil)
 	if err == nil {
 		t.Fatalf("expected error here")
+	}
+}
+
+func Test_setZero(t *testing.T) {
+
+	cases := []struct {
+		name string
+		args []byte
+	}{
+		{"nil", nil},
+		{"empty", []byte{}},
+		{"normal", []byte{1, 2, 3, 4, 5}},
+		{"large", bytes.Repeat([]byte{1, 2, 3, 4, 5}, 100)},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			setZero(tt.args)
+			if !bytes.Equal(tt.args, make([]byte, len(tt.args))) {
+				t.Errorf("setZero() = %v, want %v", tt.args, make([]byte, len(tt.args)))
+			}
+		})
 	}
 }

--- a/drbg/ctr_drbg.go
+++ b/drbg/ctr_drbg.go
@@ -162,7 +162,7 @@ func (cd *CtrDrbg) update(seedMaterial []byte) {
 	v := make([]byte, outlen)
 	output := make([]byte, outlen)
 	copy(v, cd.v)
-	for i := range (cd.seedLength+outlen-1)/outlen {
+	for i := range (cd.seedLength + outlen - 1) / outlen {
 		// V = (V + 1) mod 2^outlen
 		addOne(v, outlen)
 		// output_block = Encrypt(Key, V)
@@ -221,4 +221,9 @@ func (cd *CtrDrbg) bcc(block cipher.Block, data []byte) []byte {
 		block.Encrypt(chainingValue, chainingValue)
 	}
 	return chainingValue
+}
+
+func (cd *CtrDrbg) Destroy() {
+	cd.BaseDrbg.Destroy()
+	setZero(cd.key)
 }

--- a/drbg/ctr_drbg_test.go
+++ b/drbg/ctr_drbg_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/aes"
 	"crypto/cipher"
+	"crypto/rand"
 	"encoding/hex"
 	"testing"
 
@@ -301,5 +302,21 @@ func TestGmCtrDRBG_Validation(t *testing.T) {
 	err = hd.Reseed(entropyInput[:16], nil)
 	if err == nil {
 		t.Fatalf("expected error here")
+	}
+}
+
+func TestCtrDrbg_Destroy(t *testing.T) {
+	entropyInput := make([]byte, 64)
+	_, _ = rand.Reader.Read(entropyInput)
+	cd, err := NewCtrDrbg(sm4.NewCipher, 16, SECURITY_LEVEL_ONE, true, entropyInput[:16], entropyInput[16:24], nil)
+	if err != nil {
+		t.Errorf("NewCtrDrbg failed: %v", err)
+	}
+	cd.Destroy()
+	if !bytes.Equal(cd.key, make([]byte, len(cd.key))) {
+		t.Errorf("Destroy failed: v not zeroed")
+	}
+	if !bytes.Equal(cd.v, make([]byte, len(cd.v))) {
+		t.Errorf("Destroy failed: key not zeroed")
 	}
 }

--- a/drbg/hash_drbg.go
+++ b/drbg/hash_drbg.go
@@ -222,3 +222,10 @@ func (hd *HashDrbg) derive(seedMaterial []byte, len int) []byte {
 	}
 	return k
 }
+
+// Destroy 根据 GM/T 0105-2021 B.2 对内部状态进行清零处理
+// 内部状态组成为 {V,C, reseed_counter, last_reseed_time,reseed_interval_in_counter, reseed_interval_in_time}
+func (hd *HashDrbg) Destroy() {
+	hd.BaseDrbg.Destroy()
+	setZero(hd.c)
+}

--- a/drbg/hash_drbg_test.go
+++ b/drbg/hash_drbg_test.go
@@ -2,6 +2,7 @@ package drbg
 
 import (
 	"bytes"
+	"crypto/rand"
 	"crypto/sha1"
 	"crypto/sha256"
 	"crypto/sha512"
@@ -247,5 +248,21 @@ func TestGmHashDRBG_Validation(t *testing.T) {
 	err = hd.Reseed(entropyInput[:16], nil)
 	if err == nil {
 		t.Fatalf("expected error here")
+	}
+}
+
+func TestHashDrbg_Destroy(t *testing.T) {
+	entropyInput := make([]byte, 64)
+	_, _ = rand.Reader.Read(entropyInput)
+	hd, err := NewHashDrbg(sm3.New, SECURITY_LEVEL_ONE, true, entropyInput[:32], entropyInput[32:48], nil)
+	if err != nil {
+		t.Errorf("NewHashDrbg failed: %v", err)
+	}
+	hd.Destroy()
+	if !bytes.Equal(hd.c, make([]byte, len(hd.c))) {
+		t.Errorf("Destroy failed: v not zeroed")
+	}
+	if !bytes.Equal(hd.v, make([]byte, len(hd.v))) {
+		t.Errorf("Destroy failed: key not zeroed")
 	}
 }

--- a/drbg/hmac_drbg.go
+++ b/drbg/hmac_drbg.go
@@ -153,3 +153,10 @@ func (hd *HmacDrbg) update(byteSlices ...[]byte) error {
 	hd.v = md.Sum(hd.v[:0])
 	return nil
 }
+
+// Destroy 根据 GM/T 0105-2021 E.2 对内部状态进行清零处理
+// 内部状态组成为 {V,Key, reseed_counter, last_reseed_time,reseed_interval_in_counter, reseed_interval_in_time}
+func (hd *HmacDrbg) Destroy() {
+	hd.BaseDrbg.Destroy()
+	setZero(hd.key)
+}

--- a/drbg/hmac_drbg_test.go
+++ b/drbg/hmac_drbg_test.go
@@ -2,10 +2,12 @@ package drbg
 
 import (
 	"bytes"
+	"crypto/rand"
 	"crypto/sha1"
 	"crypto/sha256"
 	"crypto/sha512"
 	"encoding/hex"
+	"github.com/emmansun/gmsm/sm3"
 	"hash"
 	"testing"
 )
@@ -800,5 +802,21 @@ func TestHmacDRBG(t *testing.T) {
 		if !bytes.Equal(hd.key, hexDecode(tt.k3)) {
 			t.Errorf("Generate case %v failed: k3 does not match", i)
 		}
+	}
+}
+
+func TestHmacDrbg_Destroy(t *testing.T) {
+	entropyInput := make([]byte, 64)
+	_, _ = rand.Reader.Read(entropyInput)
+	hd, err := NewHmacDrbg(sm3.New, SECURITY_LEVEL_ONE, true, entropyInput[:32], entropyInput[32:48], nil)
+	if err != nil {
+		t.Errorf("NewHmacDrbg failed: %v", err)
+	}
+	hd.Destroy()
+	if !bytes.Equal(hd.key, make([]byte, len(hd.key))) {
+		t.Errorf("Destroy failed: v not zeroed")
+	}
+	if !bytes.Equal(hd.v, make([]byte, len(hd.v))) {
+		t.Errorf("Destroy failed: key not zeroed")
 	}
 }


### PR DESCRIPTION
通过内存屏障和原子指令防止编译器优化 对 GM/T 0105 D.2 E.2 出现的内部状态进行置零。